### PR TITLE
Arrange viewport for color palette visibility

### DIFF
--- a/src/components/CanvasPreview.tsx
+++ b/src/components/CanvasPreview.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { cn } from '@/lib/utils';
 
 interface CanvasPreviewProps {
   svgContent: string;
@@ -15,11 +16,23 @@ export function CanvasPreview({ svgContent }: CanvasPreviewProps) {
 
   return (
     <div className="w-full bg-muted/30 rounded-lg overflow-hidden border border-border">
-      <div className="p-8 flex items-center justify-center min-h-[400px]">
+      <div className="p-4 xl:p-8 flex items-center justify-center min-h-[400px] xl:min-h-[500px]">
         <div
           ref={containerRef}
-          className="max-w-full max-h-[600px] [&>svg]:max-w-full [&>svg]:h-auto [&>svg]:drop-shadow-2xl"
+          className={cn(
+            "max-w-full transition-all duration-300",
+            "xl:max-h-[700px] max-h-[500px]", 
+            "[&>svg]:max-w-full [&>svg]:h-auto [&>svg]:drop-shadow-2xl",
+            // Better scaling for larger viewports
+            "[&>svg]:xl:max-h-[700px] [&>svg]:max-h-[500px]"
+          )}
         />
+      </div>
+      
+      {/* Visual indicator that preview updates in real-time */}
+      <div className="px-4 pb-3 flex items-center justify-center gap-2 text-xs text-muted-foreground">
+        <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
+        <span>Live preview - changes apply instantly</span>
       </div>
     </div>
   );

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -32,21 +32,22 @@ export function ControlPanel({
   supportsTitleBar,
 }: ControlPanelProps) {
   return (
-    <div className="grid md:grid-cols-2 gap-6">
+    <div className="space-y-6">
       <div className="space-y-3">
         <label className="text-sm font-medium">
-          Title Bar {!supportsTitleBar && <span className="text-muted-foreground">(Not available for this preset)</span>}
+          Title Bar {!supportsTitleBar && <span className="text-muted-foreground">(Not available)</span>}
         </label>
-        <div className="flex gap-2">
+        <div className="grid grid-cols-3 gap-2">
           {titleBarOptions.map((option) => (
             <button
               key={option.value}
               onClick={() => onTitleBarChange(option.value)}
               disabled={!supportsTitleBar && option.value !== 'none'}
               className={cn(
-                'flex-1 px-4 py-2 rounded-lg border-2 text-sm font-medium transition-all',
+                'px-3 py-2 rounded-lg border-2 text-xs font-medium transition-all duration-200',
                 'disabled:opacity-50 disabled:cursor-not-allowed',
-                'hover:border-primary hover:bg-secondary/50',
+                'hover:border-primary hover:bg-secondary/50 hover:scale-105',
+                'focus:outline-none focus:ring-2 focus:ring-primary/50',
                 titleBar === option.value
                   ? 'border-primary bg-primary/10 text-foreground'
                   : 'border-border bg-card text-muted-foreground'
@@ -60,14 +61,15 @@ export function ControlPanel({
 
       <div className="space-y-3">
         <label className="text-sm font-medium">Aspect Ratio</label>
-        <div className="grid grid-cols-3 gap-2">
+        <div className="grid grid-cols-2 gap-2">
           {aspectRatioOptions.map((option) => (
             <button
               key={option.value}
               onClick={() => onAspectRatioChange(option.value)}
               className={cn(
-                'px-3 py-2 rounded-lg border-2 text-sm font-medium transition-all',
-                'hover:border-primary hover:bg-secondary/50',
+                'px-2 py-2 rounded-lg border-2 text-xs font-medium transition-all duration-200',
+                'hover:border-primary hover:bg-secondary/50 hover:scale-105',
+                'focus:outline-none focus:ring-2 focus:ring-primary/50',
                 aspectRatio === option.value
                   ? 'border-primary bg-primary/10 text-foreground'
                   : 'border-border bg-card text-muted-foreground'

--- a/src/components/PalettePicker.tsx
+++ b/src/components/PalettePicker.tsx
@@ -8,32 +8,72 @@ interface PalettePickerProps {
 
 export function PalettePicker({ selectedId, onChange }: PalettePickerProps) {
   return (
-    <div className="space-y-3">
-      <label className="text-sm font-medium">Color Palette</label>
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3">
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-3">
         {palettes.map((palette) => (
           <button
             key={palette.id}
             onClick={() => onChange(palette.id)}
             className={cn(
-              'p-3 rounded-lg border-2 transition-all hover:border-primary',
+              'p-4 rounded-lg border-2 transition-all duration-200 group',
+              'hover:border-primary hover:bg-primary/5 hover:scale-105',
+              'focus:outline-none focus:ring-2 focus:ring-primary/50',
               selectedId === palette.id
-                ? 'border-primary bg-primary/5'
-                : 'border-border bg-card'
+                ? 'border-primary bg-primary/10 shadow-md shadow-primary/20'
+                : 'border-border bg-card hover:shadow-sm'
             )}
           >
-            <div className="flex gap-1 mb-2">
+            {/* Color Swatches - Larger and more prominent */}
+            <div className="flex gap-1 mb-3 overflow-hidden rounded-md">
               {palette.swatches.slice(0, 5).map((color, i) => (
                 <div
                   key={i}
-                  className="flex-1 h-6 rounded"
+                  className={cn(
+                    'flex-1 h-8 transition-all duration-200',
+                    'group-hover:h-9',
+                    selectedId === palette.id && 'h-9'
+                  )}
                   style={{ backgroundColor: color }}
                 />
               ))}
             </div>
-            <div className="text-xs font-medium text-left">{palette.label}</div>
+            
+            {/* Palette Label */}
+            <div className={cn(
+              'text-xs font-medium text-left transition-colors',
+              selectedId === palette.id 
+                ? 'text-primary' 
+                : 'text-muted-foreground group-hover:text-foreground'
+            )}>
+              {palette.label}
+            </div>
+
+            {/* Selected indicator */}
+            {selectedId === palette.id && (
+              <div className="flex items-center gap-1 mt-2">
+                <div className="w-2 h-2 bg-primary rounded-full animate-pulse" />
+                <span className="text-xs text-primary font-medium">Selected</span>
+              </div>
+            )}
           </button>
         ))}
+      </div>
+      
+      {/* Quick palette preview - shows current selection prominently */}
+      <div className="p-3 bg-accent/5 border border-accent/20 rounded-lg">
+        <div className="text-xs font-medium text-accent mb-2">Current Selection</div>
+        <div className="flex gap-1 rounded-md overflow-hidden">
+          {palettes.find(p => p.id === selectedId)?.swatches.map((color, i) => (
+            <div
+              key={i}
+              className="flex-1 h-6"
+              style={{ backgroundColor: color }}
+            />
+          ))}
+        </div>
+        <div className="text-xs text-muted-foreground mt-2">
+          {palettes.find(p => p.id === selectedId)?.label}
+        </div>
       </div>
     </div>
   );

--- a/src/components/PresetPicker.tsx
+++ b/src/components/PresetPicker.tsx
@@ -9,17 +9,17 @@ interface PresetPickerProps {
 export function PresetPicker({ selectedId, onChange }: PresetPickerProps) {
   return (
     <div className="space-y-3">
-      <label className="text-sm font-medium">Preset Style</label>
-      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2">
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-2">
         {presets.map((preset) => (
           <button
             key={preset.id}
             onClick={() => onChange(preset.id)}
             className={cn(
-              'px-4 py-3 rounded-lg border-2 text-sm font-medium transition-all',
-              'hover:border-primary hover:bg-secondary/50',
+              'px-3 py-2.5 rounded-lg border-2 text-xs font-medium transition-all duration-200',
+              'hover:border-primary hover:bg-secondary/50 hover:scale-105',
+              'focus:outline-none focus:ring-2 focus:ring-primary/50',
               selectedId === preset.id
-                ? 'border-primary bg-primary/10 text-foreground'
+                ? 'border-primary bg-primary/10 text-foreground shadow-sm'
                 : 'border-border bg-card text-muted-foreground'
             )}
           >

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -223,45 +223,59 @@ const Index = () => {
         </div>
 
         {imageData && (
-          <div className="space-y-8 animate-fade-in-up">
-            {/* Preview */}
-            <div>
-              <h2 className="text-lg font-semibold mb-4">Preview</h2>
-              <CanvasPreview svgContent={svgContent} />
-            </div>
+          <div className="animate-fade-in-up">
+            {/* Two-column layout for larger screens, single column for smaller screens */}
+            <div className="flex flex-col xl:flex-row gap-8">
+              {/* Main content area - Preview and Export */}
+              <div className="flex-1 space-y-6">
+                {/* Preview */}
+                <div>
+                  <h2 className="text-lg font-semibold mb-4">Preview</h2>
+                  <CanvasPreview svgContent={svgContent} />
+                </div>
 
-            {/* Export */}
-            <div>
-              <h2 className="text-lg font-semibold mb-4">Export</h2>
-              <ExportButtons
-                svgContent={svgContent}
-                onExport={handleExport}
-                disabled={!svgContent}
-              />
-            </div>
+                {/* Export */}
+                <div>
+                  <h2 className="text-lg font-semibold mb-4">Export</h2>
+                  <ExportButtons
+                    svgContent={svgContent}
+                    onExport={handleExport}
+                    disabled={!svgContent}
+                  />
+                </div>
+              </div>
 
-            {/* Preset Selection */}
-            <div>
-              <h2 className="text-lg font-semibold mb-4">Style Preset</h2>
-              <PresetPicker selectedId={presetId} onChange={setPresetId} />
-            </div>
+              {/* Controls sidebar for larger screens */}
+              <div className="xl:w-96 xl:sticky xl:top-24 xl:self-start">
+                <div className="space-y-6 xl:bg-card/50 xl:backdrop-blur-sm xl:border xl:border-border xl:rounded-lg xl:p-6">
+                  {/* Palette Selection - Most prominent */}
+                  <div>
+                    <h2 className="text-lg font-semibold mb-4 flex items-center gap-2">
+                      <span className="w-3 h-3 bg-gradient-to-r from-primary to-accent rounded-full"></span>
+                      Color Palette
+                    </h2>
+                    <PalettePicker selectedId={paletteId} onChange={setPaletteId} />
+                  </div>
 
-            {/* Palette Selection */}
-            <div>
-              <h2 className="text-lg font-semibold mb-4">Color Palette</h2>
-              <PalettePicker selectedId={paletteId} onChange={setPaletteId} />
-            </div>
+                  {/* Preset Selection */}
+                  <div>
+                    <h2 className="text-lg font-semibold mb-4">Style Preset</h2>
+                    <PresetPicker selectedId={presetId} onChange={setPresetId} />
+                  </div>
 
-            {/* Controls */}
-            <div>
-              <h2 className="text-lg font-semibold mb-4">Options</h2>
-              <ControlPanel
-                titleBar={titleBar}
-                aspectRatio={aspectRatio}
-                onTitleBarChange={setTitleBar}
-                onAspectRatioChange={setAspectRatio}
-                supportsTitleBar={currentPreset.supportsTitle}
-              />
+                  {/* Controls */}
+                  <div>
+                    <h2 className="text-lg font-semibold mb-4">Options</h2>
+                    <ControlPanel
+                      titleBar={titleBar}
+                      aspectRatio={aspectRatio}
+                      onTitleBarChange={setTitleBar}
+                      onAspectRatioChange={setAspectRatio}
+                      supportsTitleBar={currentPreset.supportsTitle}
+                    />
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
Implement a two-column layout for large screens, moving controls to a sticky sidebar and enhancing the color palette picker.

This ensures color palettes are easy to choose and their effects are visible without scrolling on 1920x1080+ resolutions.

---
<a href="https://cursor.com/background-agent?bcId=bc-02c94297-76ac-457a-a069-71a798483450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-02c94297-76ac-457a-a069-71a798483450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

